### PR TITLE
Fix Special Field documentation

### DIFF
--- a/guide/special-field.md
+++ b/guide/special-field.md
@@ -19,10 +19,10 @@ Here is an example,
   api-url="..."
   :fields="fields"
 >
-  <div slot="gender-slot" slot-scope="props">
-    <span v-if="props.rowData.gender === 'M'" class="ui teal label"><i class="large man icon"></i>Male</span>
+  <template #genderSlot="{ rowData }">
+    <span v-if="rowData.gender === 'M'" class="ui teal label"><i class="large man icon"></i>Male</span>
     <span v-else class="ui pink label"><i class="large woman icon"></i>Female</span>
-  </div>
+  </template>
 </vuetable>
 ```
 
@@ -32,7 +32,7 @@ new Vue({
     fields:     [
       //...
       {
-        name: "gender-slot",
+        name: "__slot:genderSlot",
         title: '<i class="grey heterosexual icon"></i>Gender',
         titleClass: "center aligned",
         dataClass: "center aligned",


### PR DESCRIPTION
The example in the documentation is currently not working and using deprecated syntax according to Vue's documentation (https://vuejs.org/v2/guide/components-slots.html#Deprecated-Syntax).

I got it to work by adding a `__slot:` prefix in the field's name. Additionally, the non-deprecated slot syntax is also a lot more concise and supports destructuring as well. I incorporated that as well. I was not sure whether dashes are allowed in slot names, so I just changed the name to `genderSlot` just to be sure.