### PR TITLE
Fix row-class example code

### DIFF
--- a/api/vuetable/properties.md
+++ b/api/vuetable/properties.md
@@ -332,7 +332,7 @@ sidebarDepth: 2
   Here is the example on using a method to return the row class for styling.
   ```vue
   <template>
-    <vuetable>
+    <vuetable
       :row-class="onRowClass"
     ></vuetable>
   </template>


### PR DESCRIPTION
Remove an extra greater than in the row-class example code.